### PR TITLE
Link 컴포넌트 수정 + Header에 Link 추가 + Button 컴포넌트 수정

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import styles from './Button.module.css'
 
 interface ButtonProps {
-  onClick: () => void
+  onClick?: () => void
   option: number
   label: string
   className: string

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -1,6 +1,6 @@
 import { Swiper, SwiperSlide } from 'swiper/react'
 import { Autoplay, Pagination } from 'swiper'
-import { Title, Text, Button } from '@/components'
+import { Title, Text, Button, Link } from '@/components'
 import 'swiper/css'
 import 'swiper/css/navigation'
 import 'swiper/css/pagination'
@@ -19,10 +19,6 @@ const Carousel = ({ className }: CarouselProps) => {
 
   const goHome = () => {
     navigate('/home')
-  }
-
-  const goDetail = () => {
-    navigate('/detail')
   }
 
   const goSchool = () => {
@@ -117,12 +113,15 @@ const Carousel = ({ className }: CarouselProps) => {
                 만들수 있는 '공유주방'과 같은 <br />
                 개념입니다.
               </Text>
-              <Button
-                className={`${styles['contents-button']} ${styles['button-third']}`}
-                option={1}
-                onClick={goDetail}
-                label="바로가기"
-              ></Button>
+              <div>
+                <Link path="http://hunmin.demo.t3q.ai/ADVENTURE">
+                  <Button
+                    className={`${styles['contents-button']} ${styles['button-third']}`}
+                    option={1}
+                    label="바로가기"
+                  ></Button>
+                </Link>
+              </div>
             </div>
           </section>
         </SwiperSlide>

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -1,15 +1,8 @@
 @import '../../root.css';
 
-.link--primary {
-  text-decoration: none;
-  font-weight: var(--font-semibold);
-  font-size: var(--font-16);
+.link {
   color: var(--font-gray-heavy);
+  font-size: var(--font-16);
+  font-weight: var(--font-semibold);
+  text-decoration: none;
 }
-
-/*
-.link--secondary {
-}
-
-.link—third {
-} */

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,24 +1,17 @@
 import { Link as ReactRouterLink } from 'react-router-dom'
+import { ReactNode } from 'react'
 import styles from './Link.module.css'
 
 interface LinkProps {
   path: string
-  label: string
-  option: number
-  className: string
+  children?: ReactNode
+  className?: string
 }
 
-const Link = ({ path, label, option, className }: LinkProps) => {
-  const mode =
-    option === 1
-      ? styles['link--primary']
-      : option === 2
-      ? styles['link--secondary']
-      : styles['link--third']
-
+const Link = ({ path, children, className }: LinkProps) => {
   return (
-    <ReactRouterLink to={path} className={`${mode} ${className}`}>
-      {label}
+    <ReactRouterLink to={path} className={`${styles.link} ${className}`}>
+      {children}
     </ReactRouterLink>
   )
 }

--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -6,19 +6,19 @@ const Header = () => {
   return (
     <div className={styles.header}>
       <div className={styles['header-inner']}>
-        <Logo className={styles.logo}></Logo>
+        <Link path="/">
+          <Logo className={styles.logo}></Logo>
+        </Link>
         <div className={styles.links}>
           <Link
             className={`${styles.experience}`}
-            path="/"
-            label="T3Q.ai 체험하기"
-            option={1}
+            path="http://hunmin.demo.t3q.ai/ADVENTURE"
+            children="T3Q.ai 체험하기"
           />
           <Link
             className={`${styles.login}`}
-            path="/"
-            label="로그인"
-            option={1}
+            path="http://hunmin.demo.t3q.ai:8080/auth/realms/t3q_ai_edu/protocol/openid-connect/auth?client_id=common&response_type=code&redirect_uri=http://hunmin.demo.t3q.ai/page-redirector/signIn-AIHUNMIN&scope=openid&state=toAnP"
+            children="로그인"
           />
         </div>
       </div>


### PR DESCRIPTION
<img width="790" alt="image" src="https://github.com/sosin-t3q/education-system/assets/96248861/2bc7b8be-c7c8-43f4-a558-790719e89a9a">

- 버튼 컴포넌트의 onClick props가 옵셔널로 변경되었습니다.

<img width="828" alt="image" src="https://github.com/sosin-t3q/education-system/assets/96248861/ff7cade0-93dd-4275-8492-fb7afcc94b31">

- Intro 페이지의 플랫폼 체험해보기 버튼을 외부 사이트로 이동하기 위해서 마크업 일부가 수정되었습니다.

<img width="738" alt="image" src="https://github.com/sosin-t3q/education-system/assets/96248861/82849403-8fcd-4314-9db4-8fd73739a260">

- Link 컴포넌트의 마크업이 변경되었습니다. props label이 children으로 대체되었습니다.