### PR TITLE
[🔧수정] apiURL state 상태 끌어올리기

### DIFF
--- a/src/components/ApiURL/ApiURL.tsx
+++ b/src/components/ApiURL/ApiURL.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import styles from './ApiURL.module.css'
 
 interface ApiURLProps {
   api: string | null
+  apiURL: string;
+  setApiURL: any;
 }
 
-const ApiURL = ({ api }: ApiURLProps) => {
-  const [apiURL, setApiURL] = useState<string>('')
+const ApiURL = ({ api, apiURL, setApiURL }: ApiURLProps) => {
 
   useEffect(() => {
     if (api) {

--- a/src/containers/DetailForm/DetailForm.tsx
+++ b/src/containers/DetailForm/DetailForm.tsx
@@ -8,8 +8,8 @@ import {
 } from '@/components'
 import styles from './DetailForm.module.css'
 import { useCallback, useEffect, useState } from 'react'
-import { detailDataAtom, inputValidationAtom } from '@/atoms/index'
-import { useRecoilState } from 'recoil'
+import { detailDataAtom, inputValidationAtom, loadingAtom, resultAtom } from '@/atoms/index'
+import { useRecoilState, useSetRecoilState } from 'recoil'
 import { DataType } from '@/pages/Detail/Detail'
 
 type SelectedFileType = Record<string, string> | null | undefined
@@ -19,11 +19,13 @@ interface DetailFormProps {
   pageId: string | undefined
 }
 
+
 const DetailForm = ({ data, pageId }: DetailFormProps) => {
   const [selected, setSelected] = useState('default')
   const [selectedFile, setSelectedFile] = useState<SelectedFileType>(null)
   const [value, setValue] = useRecoilState(detailDataAtom)
   const [isValid] = useRecoilState(inputValidationAtom)
+  const [apiURL, setApiURL] = useState<string>('')
   const fileList = data &&
     data['data_list'] && [
       '예제 선택하기',
@@ -54,8 +56,6 @@ const DetailForm = ({ data, pageId }: DetailFormProps) => {
   const onClick = useCallback(() => {
     if (value) {
       alert(value)
-      console.log(pageId)
-      // 데이터 통신 로직
     } else if (!isValid.isValid) {
       alert(isValid.message)
     }
@@ -72,7 +72,7 @@ const DetailForm = ({ data, pageId }: DetailFormProps) => {
         label={'예제 실행해보기'}
         className={'detailform-title'}
       />
-      <ApiURL api={data && data.API} />
+      <ApiURL api={data && data.API} apiURL={apiURL} setApiURL={setApiURL} />
       <div className={styles['input-cont']}>
         {data && (
           <Input


### PR DESCRIPTION
![image](https://github.com/sosin-t3q/education-system/assets/79128016/b6a62af8-7f2c-400a-8750-22c7232af4f8)

![image](https://github.com/sosin-t3q/education-system/assets/79128016/1d14739d-f704-461b-9ff9-f4cd040885c4)

- 기존의 apiURL state를 DetailForm.tsx로 끌어올렸습니다.