### PR TITLE
Axios 비동기 통신 함수 수정과 Intro 버튼 태그를 수정하였습니다.

### DIFF
--- a/src/axios/case28/audio/audio_anomaly.tsx
+++ b/src/axios/case28/audio/audio_anomaly.tsx
@@ -8,7 +8,7 @@ const audioAnomaly = async (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'audio', 'audio/wav')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()
@@ -51,7 +51,7 @@ const audioAnomaly = async (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default audioAnomaly

--- a/src/axios/case28/audio/audio_classification.tsx
+++ b/src/axios/case28/audio/audio_classification.tsx
@@ -8,7 +8,7 @@ const audioClassification = async (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'audio', 'audio/wav')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()
@@ -45,7 +45,7 @@ const audioClassification = async (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default audioClassification

--- a/src/axios/case28/audio/audio_clustering.tsx
+++ b/src/axios/case28/audio/audio_clustering.tsx
@@ -14,7 +14,7 @@ const audioClustering = async (
     Sneezing: '재채기',
   }
 
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'audio', 'audio/wav')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()
@@ -53,7 +53,7 @@ const audioClustering = async (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default audioClustering

--- a/src/axios/case28/audio/audio_regression.tsx
+++ b/src/axios/case28/audio/audio_regression.tsx
@@ -8,7 +8,7 @@ const audioRegression = async (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'audio', 'audio/midi')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()
@@ -48,7 +48,7 @@ const audioRegression = async (
     .finally(() => {
       setLoading(false)
     })
-    return resultData
+  return resultData
 }
 
 export default audioRegression

--- a/src/axios/case28/binary/binary_anomaly.tsx
+++ b/src/axios/case28/binary/binary_anomaly.tsx
@@ -8,7 +8,7 @@ const binaryAnomaly = async (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'image', 'image/png')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()

--- a/src/axios/case28/binary/binary_classification.tsx
+++ b/src/axios/case28/binary/binary_classification.tsx
@@ -8,7 +8,7 @@ const binaryClassification = async (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'image', 'image/png')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()
@@ -50,7 +50,7 @@ const binaryClassification = async (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default binaryClassification

--- a/src/axios/case28/binary/binary_clustering.tsx
+++ b/src/axios/case28/binary/binary_clustering.tsx
@@ -8,7 +8,7 @@ const binaryClustering = async (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'image', 'image/png')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()

--- a/src/axios/case28/binary/binary_regression.tsx
+++ b/src/axios/case28/binary/binary_regression.tsx
@@ -7,19 +7,22 @@ const binaryRegression = (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/log_req_ajx' // 고정값
-  /* FormData (apiUrl, data) 형태로 전송 */
-  const formData = new FormData()
-  formData.append('url', formUrl)
-  formData.append('word', value) // 사용자가 전송할 값이 [문자열] 형태일 때
+  const axiosUrl = 'api/inference/log_req_ajx' // 고정값
+  // axiosUrl 이 text 또는 log일 때는 JSON.stringify 형태로 전송
+  const jsonData = JSON.stringify({
+    url: formUrl,
+    log_data: value,
+  })
 
   let resultData = ''
+
   setLoading(true) // 로딩 표시
+
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, formData, {
+    .post(axiosUrl, jsonData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
+        'Content-Type': 'application/json',
       },
       responseType: 'json',
     })

--- a/src/axios/case28/image/image_anomaly.tsx
+++ b/src/axios/case28/image/image_anomaly.tsx
@@ -8,7 +8,7 @@ const imageAnomaly = async (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'image', 'image/jpeg')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()

--- a/src/axios/case28/image/image_classification.tsx
+++ b/src/axios/case28/image/image_classification.tsx
@@ -21,7 +21,7 @@ const imageClassification = async (
     pig: '돼지',
   }
 
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'image', 'image/png')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()
@@ -29,6 +29,7 @@ const imageClassification = async (
   formData.append('file', convertData) // 사용자가 전송할 값이 [문자열] 형태일 때
 
   let resultData = ''
+  console.log(formData)
   setLoading(true) // 로딩 표시
 
   /* axios 비동기 통신 함수 */

--- a/src/axios/case28/image/image_clustering.tsx
+++ b/src/axios/case28/image/image_clustering.tsx
@@ -14,7 +14,7 @@ const imageCluster = async (
     sunglasses: '선글라스',
   }
 
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'image', 'image/png')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()
@@ -54,7 +54,7 @@ const imageCluster = async (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default imageCluster

--- a/src/axios/case28/image/image_regression.tsx
+++ b/src/axios/case28/image/image_regression.tsx
@@ -8,7 +8,7 @@ const imageRegression = async (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'image', 'image/jpeg')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()
@@ -36,7 +36,7 @@ const imageRegression = async (
         /* 결과값에 따라 결과 컴포넌트 렌더링 */
         /* response_data => 이미지 base64 src */
         const content_result = 'data:image/jpg;base64,' + response_data
-        const content_curriculum = json.response.inference_curriculum
+        // const content_curriculum = json.response.inference_curriculum
         // $("#resImgSrc").attr("src", "data:image/jpg;base64," + content_curriculum);
         // $("div.inner_next").addClass("show_img");
         resultData = content_result
@@ -50,7 +50,7 @@ const imageRegression = async (
     .finally(() => {
       setLoading(false)
     })
-    return resultData;
+  return resultData
 }
 
 export default imageRegression

--- a/src/axios/case28/log/log_anomaly.tsx
+++ b/src/axios/case28/log/log_anomaly.tsx
@@ -7,20 +7,22 @@ const logAnomaly = (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/log_req_ajx' // 고정값
-  /* FormData (apiUrl, data) 형태로 전송 */
-  const formData = new FormData()
-  formData.append('url', formUrl)
-  formData.append('word', value) // 사용자가 전송할 값이 [문자열] 형태일 때
+  const axiosUrl = 'api/inference/log_req_ajx' // 고정값
+  // axiosUrl 이 text 또는 log일 때는 JSON.stringify 형태로 전송
+  const jsonData = JSON.stringify({
+    url: formUrl,
+    log_data: value,
+  })
 
   let resultData = ''
+
   setLoading(true) // 로딩 표시
 
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, formData, {
+    .post(axiosUrl, jsonData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
+        'Content-Type': 'application/json',
       },
       responseType: 'json',
     })

--- a/src/axios/case28/log/log_classification.tsx
+++ b/src/axios/case28/log/log_classification.tsx
@@ -8,20 +8,22 @@ const logClassification = (
   // setResult: any,    // 결과 컴포넌트
 ) => {
   const class_info: any = { Center: '센터', Guard: '가드', Forward: '포워드' }
-  const axiosUrl = '/inference/log_req_ajx' // 고정값
-  /* FormData (apiUrl, data) 형태로 전송 */
-  const formData = new FormData()
-  formData.append('url', formUrl)
-  formData.append('word', value) // 사용자가 전송할 값이 [문자열] 형태일 때
+  const axiosUrl = 'api/inference/log_req_ajx' // 고정값
+  // axiosUrl 이 text 또는 log일 때는 JSON.stringify 형태로 전송
+  const jsonData = JSON.stringify({
+    url: formUrl,
+    log_data: value,
+  })
 
   let resultData = ''
+
   setLoading(true) // 로딩 표시
 
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, formData, {
+    .post(axiosUrl, jsonData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
+        'Content-Type': 'application/json',
       },
       //서버로부터 들어오는 응답값은 JSON 형식
       responseType: 'json',
@@ -49,7 +51,7 @@ const logClassification = (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default logClassification

--- a/src/axios/case28/log/log_clustering.tsx
+++ b/src/axios/case28/log/log_clustering.tsx
@@ -14,20 +14,21 @@ const logClustering = (
     'physical bad, magical bad': '모든 능력치 부족',
   }
 
-  const axiosUrl = '/inference/log_req_ajx' // 고정값
-  /* FormData (apiUrl, data) 형태로 전송 */
-  const formData = new FormData()
-  formData.append('url', formUrl)
-  formData.append('word', value) // 사용자가 전송할 값이 [문자열] 형태일 때
+  const axiosUrl = 'api/inference/log_req_ajx' // 고정값
+  // axiosUrl 이 text 또는 log일 때는 JSON.stringify 형태로 전송
+  const jsonData = JSON.stringify({
+    url: formUrl,
+    log_data: value,
+  })
 
   let resultData = ''
   setLoading(true) // 로딩 표시
 
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, formData, {
+    .post(axiosUrl, jsonData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
+        'Content-Type': 'application/json',
       },
       responseType: 'json',
     })
@@ -53,7 +54,7 @@ const logClustering = (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default logClustering

--- a/src/axios/case28/log/log_regression.tsx
+++ b/src/axios/case28/log/log_regression.tsx
@@ -7,20 +7,22 @@ const logRegression = (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/log_req_ajx' // 고정값
-  /* FormData (apiUrl, data) 형태로 전송 */
-  const formData = new FormData()
-  formData.append('url', formUrl)
-  formData.append('word', value) // 사용자가 전송할 값이 [문자열] 형태일 때
+  const axiosUrl = 'api/inference/log_req_ajx' // 고정값
+  // axiosUrl 이 text 또는 log일 때는 JSON.stringify 형태로 전송
+  const jsonData = JSON.stringify({
+    url: formUrl,
+    log_data: value,
+  })
 
   let resultData = ''
+
   setLoading(true) // 로딩 표시
 
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, formData, {
+    .post(axiosUrl, jsonData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
+        'Content-Type': 'application/json',
       },
       responseType: 'json',
     })
@@ -45,7 +47,7 @@ const logRegression = (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default logRegression

--- a/src/axios/case28/satellite/satellite_anomaly.tsx
+++ b/src/axios/case28/satellite/satellite_anomaly.tsx
@@ -7,20 +7,22 @@ const satelliteAnomaly = (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/log_req_ajx' // 고정값
-  /* FormData (apiUrl, data) 형태로 전송 */
-  const formData = new FormData()
-  formData.append('url', formUrl)
-  formData.append('word', value) // 사용자가 전송할 값이 [문자열] 형태일 때
+  const axiosUrl = 'api/inference/log_req_ajx' // 고정값
+  // axiosUrl 이 text 또는 log일 때는 JSON.stringify 형태로 전송
+  const jsonData = JSON.stringify({
+    url: formUrl,
+    log_data: value,
+  })
 
   let resultData = ''
+
   setLoading(true) // 로딩 표시
 
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, formData, {
+    .post(axiosUrl, jsonData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
+        'Content-Type': 'application/json',
       },
       responseType: 'json',
     })
@@ -50,7 +52,7 @@ const satelliteAnomaly = (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default satelliteAnomaly

--- a/src/axios/case28/satellite/satellite_classification.tsx
+++ b/src/axios/case28/satellite/satellite_classification.tsx
@@ -16,7 +16,7 @@ const satelliteClassification = async (
     runway: '일반도로',
   }
 
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'image', 'image/png')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()

--- a/src/axios/case28/satellite/satellite_clustering.tsx
+++ b/src/axios/case28/satellite/satellite_clustering.tsx
@@ -10,7 +10,7 @@ const satelliteClustering = async (
 ) => {
   const class_info: any = { forested: '산림화', desertified: '사막화' }
 
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'image', 'image/png')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()
@@ -48,7 +48,7 @@ const satelliteClustering = async (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default satelliteClustering

--- a/src/axios/case28/satellite/satellite_regression.tsx
+++ b/src/axios/case28/satellite/satellite_regression.tsx
@@ -8,7 +8,7 @@ const satelliteRegression = async (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'image', 'image/jpeg')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()
@@ -45,7 +45,7 @@ const satelliteRegression = async (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default satelliteRegression

--- a/src/axios/case28/text/text_anomaly.ts
+++ b/src/axios/case28/text/text_anomaly.ts
@@ -9,7 +9,7 @@ const textAnomaly = (
 ) => {
   const axiosUrl = 'api/inference/text_req_ajx' // 고정값
   // axiosUrl 이 text 또는 log일 때는 JSON.stringify 형태로 전송
-  const convertData = JSON.stringify({
+  const jsonData = JSON.stringify({
     word: value,
     url: formUrl,
   })
@@ -18,7 +18,7 @@ const textAnomaly = (
 
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, convertData, {
+    .post(axiosUrl, jsonData, {
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/axios/case28/text/text_anomaly.ts
+++ b/src/axios/case28/text/text_anomaly.ts
@@ -7,20 +7,20 @@ const textAnomaly = (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/text_req_ajx' // 고정값
-  /* FormData (apiUrl, data) 형태로 전송 */
-  const formData = new FormData()
-  formData.append('url', formUrl)
-  formData.append('word', value) // 사용자가 전송할 값이 [문자열] 형태일 때
-
+  const axiosUrl = 'api/inference/text_req_ajx' // 고정값
+  // axiosUrl 이 text 또는 log일 때는 JSON.stringify 형태로 전송
+  const convertData = JSON.stringify({
+    word: value,
+    url: formUrl,
+  })
   let resultData = ''
   setLoading(true) // 로딩 표시
 
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, formData, {
+    .post(axiosUrl, convertData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
+        'Content-Type': 'application/json',
       },
       //서버로부터 들어오는 응답값은 JSON 형식
       responseType: 'json',

--- a/src/axios/case28/text/text_classification.ts
+++ b/src/axios/case28/text/text_classification.ts
@@ -11,7 +11,7 @@ const textClassification = (
 ) => {
   const axiosUrl = 'api/inference/text_req_ajx' // 고정값
   // axiosUrl 이 text 또는 log일 때는 JSON.stringify 형태로 전송
-  const convertData = JSON.stringify({
+  const jsonData = JSON.stringify({
     word: value,
     url: formUrl,
   })
@@ -20,7 +20,7 @@ const textClassification = (
 
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, convertData, {
+    .post(axiosUrl, jsonData, {
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/axios/case28/text/text_classification.ts
+++ b/src/axios/case28/text/text_classification.ts
@@ -9,20 +9,20 @@ const textClassification = (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/text_req_ajx' // 고정값
-  /* FormData (apiUrl, data) 형태로 전송 */
-  const formData = new FormData()
-  formData.append('url', formUrl)
-  formData.append('word', value) // 사용자가 전송할 값이 [문자열] 형태일 때
-  //  formData.append("file", value);   // 사용자가 전송할 값이 [파일] 형태일 때
+  const axiosUrl = 'api/inference/text_req_ajx' // 고정값
+  // axiosUrl 이 text 또는 log일 때는 JSON.stringify 형태로 전송
+  const convertData = JSON.stringify({
+    word: value,
+    url: formUrl,
+  })
   let resultData = ''
   setLoading(true) // 로딩 표시
 
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, formData, {
+    .post(axiosUrl, convertData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
+        'Content-Type': 'application/json',
       },
       responseType: 'json',
     })

--- a/src/axios/case28/text/text_clustering.ts
+++ b/src/axios/case28/text/text_clustering.ts
@@ -10,7 +10,7 @@ const textClustering = (
   const cluster_info: any = { rec: '취미', comp: '컴퓨터' }
   const axiosUrl = 'api/inference/text_req_ajx' // 고정값
   // axiosUrl의 값이 text 또는 log로 전송할 때는 JSON.stringify 형태로 전송
-  const convertData = JSON.stringify({
+  const jsonData = JSON.stringify({
     word: value.replaceAll('?', '\\?'),
     url: formUrl,
   })
@@ -20,7 +20,7 @@ const textClustering = (
 
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, convertData, {
+    .post(axiosUrl, jsonData, {
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/axios/case28/text/text_clustering.ts
+++ b/src/axios/case28/text/text_clustering.ts
@@ -8,20 +8,21 @@ const textClustering = (
   // setResult: any,    // 결과 컴포넌트
 ) => {
   const cluster_info: any = { rec: '취미', comp: '컴퓨터' }
-  const axiosUrl = '/inference/text_req_ajx' // 고정값
-  /* FormData (apiUrl, data) 형태로 전송 */
-  const formData = new FormData()
-  formData.append('url', formUrl)
-  formData.append('word', value.replaceAll('?', '\\?'))
+  const axiosUrl = 'api/inference/text_req_ajx' // 고정값
+  // axiosUrl의 값이 text 또는 log로 전송할 때는 JSON.stringify 형태로 전송
+  const convertData = JSON.stringify({
+    word: value.replaceAll('?', '\\?'),
+    url: formUrl,
+  })
 
   let resultData = ''
   setLoading(true) // 로딩 표시
 
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, formData, {
+    .post(axiosUrl, convertData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
+        'Content-Type': 'application/json',
       },
       //서버로부터 들어오는 응답값은 JSON 형식
       responseType: 'json',
@@ -48,7 +49,7 @@ const textClustering = (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default textClustering

--- a/src/axios/case28/text/text_regression.ts
+++ b/src/axios/case28/text/text_regression.ts
@@ -7,12 +7,13 @@ const textRegression = (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/text_req_ajx' // 고정값
-  /* FormData (apiUrl, data) 형태로 전송 */
-  const formData = new FormData()
-  formData.append('url', formUrl)
-  formData.append('word', value) // 사용자가 전송할 값이 [문자열] 형태일 때
-  //  formData.append("file", value);   // 사용자가 전송할 값이 [파일] 형태일 때
+  const axiosUrl = 'api/inference/text_req_ajx' // 고정값
+
+  // axiosUrl 이 text 또는 log일 때는 JSON.stringify 형태로 전송
+  const convertData = JSON.stringify({
+    word: value,
+    url: formUrl,
+  })
 
   let resultData = ''
 
@@ -20,9 +21,9 @@ const textRegression = (
 
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, formData, {
+    .post(axiosUrl, convertData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
+        'Content-Type': 'application/json',
       },
       responseType: 'json',
     })

--- a/src/axios/case28/text/text_regression.ts
+++ b/src/axios/case28/text/text_regression.ts
@@ -10,7 +10,7 @@ const textRegression = (
   const axiosUrl = 'api/inference/text_req_ajx' // 고정값
 
   // axiosUrl 이 text 또는 log일 때는 JSON.stringify 형태로 전송
-  const convertData = JSON.stringify({
+  const jsonData = JSON.stringify({
     word: value,
     url: formUrl,
   })
@@ -21,7 +21,7 @@ const textRegression = (
 
   /* axios 비동기 통신 함수 */
   axios
-    .post(axiosUrl, convertData, {
+    .post(axiosUrl, jsonData, {
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/axios/case28/video/video_anomaly.tsx
+++ b/src/axios/case28/video/video_anomaly.tsx
@@ -7,7 +7,7 @@ const videoAnomaly = async (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'gifImage', 'image/gif')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()
@@ -50,7 +50,7 @@ const videoAnomaly = async (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default videoAnomaly

--- a/src/axios/case28/video/video_classification.tsx
+++ b/src/axios/case28/video/video_classification.tsx
@@ -15,7 +15,7 @@ const videoClassification = async (
     TennisSwing: '테니스 스윙',
   }
 
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'video', 'video/mp4')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()
@@ -53,7 +53,7 @@ const videoClassification = async (
     .finally(() => {
       setLoading(false)
     })
-    return {label: resultData}
+  return { label: resultData }
 }
 
 export default videoClassification

--- a/src/axios/case28/video/video_clustering.tsx
+++ b/src/axios/case28/video/video_clustering.tsx
@@ -7,7 +7,7 @@ const videoClustering = async (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'gifImage', 'image/gif')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()

--- a/src/axios/case28/video/video_regression.tsx
+++ b/src/axios/case28/video/video_regression.tsx
@@ -7,7 +7,7 @@ const videoRegression = async (
   setLoading: any, // 로딩
   // setResult: any,    // 결과 컴포넌트
 ) => {
-  const axiosUrl = '/inference/file_req_ajx' // 고정값
+  const axiosUrl = 'api/inference/file_req_ajx' // 고정값
   const convertData = await base64DataToFile(value, 'gifImage', 'image/gif')
   /* FormData (apiUrl, data) 형태로 전송 */
   const formData = new FormData()
@@ -47,7 +47,7 @@ const videoRegression = async (
     .finally(() => {
       setLoading(false)
     })
-    return resultData
+  return resultData
 }
 
 export default videoRegression

--- a/src/components/Carousel/Carousel.module.css
+++ b/src/components/Carousel/Carousel.module.css
@@ -34,3 +34,23 @@
   cursor: pointer;
   margin-top: var(--margin-100);
 }
+
+.adventure-button {
+  width: 93px;
+  height: 41px;
+  background-color: var(--font-blue);
+  border-radius: var(--border-radius-4);
+  margin-top: var(--margin-100);
+}
+
+.adventure-button a {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+  font-size: var(--font-18);
+  color: var(--font-white);
+  font-weight: var(--font-semibold);
+}

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -1,6 +1,6 @@
 import { Swiper, SwiperSlide } from 'swiper/react'
 import { Autoplay, Pagination } from 'swiper'
-import { Title, Text, Button, Link } from '@/components'
+import { Title, Text, Button } from '@/components'
 import 'swiper/css'
 import 'swiper/css/navigation'
 import 'swiper/css/pagination'
@@ -113,14 +113,8 @@ const Carousel = ({ className }: CarouselProps) => {
                 만들수 있는 '공유주방'과 같은 <br />
                 개념입니다.
               </Text>
-              <div>
-                <Link path="http://hunmin.demo.t3q.ai/ADVENTURE">
-                  <Button
-                    className={`${styles['contents-button']} ${styles['button-third']}`}
-                    option={1}
-                    label="바로가기"
-                  ></Button>
-                </Link>
+              <div className={styles['adventure-button']}>
+                <a href="/adventure">바로가기</a>
               </div>
             </div>
           </section>


### PR DESCRIPTION
### 변경사항

<img width="597" alt="image" src="https://github.com/sosin-t3q/education-system/assets/96248861/3eeddab7-f273-4b45-b8d7-7bb02bfbbb5d">
<img width="597" alt="image" src="https://github.com/sosin-t3q/education-system/assets/96248861/4a5a3ef3-4318-444d-b8c6-db309816a59e">

- Intro 페이지의 3번째 (t3q.AI 플랫폼 체험해보기) 버튼이 기존 <Link/> 에서 <a/> 태그로 변경되었습니다.
- 외부 링크로 이동하기 때문에 요청에 따라 a태그로 변경하고 div로 감싸준 형태입니다.

<img width="515" alt="image" src="https://github.com/sosin-t3q/education-system/assets/96248861/7f7478ee-fced-4891-a9bd-19502fe518f1">

- 28가지 비동기 통신함수들의 Axios URL이 변경되었습니다.
- log_req_ajx 와 text_req_ajx로 통신하기 위해서 기존 formData에서 json.stringify를 통해 전송할 수 있도록 변경되었습니다.

- log_req_ajx 는 value값을 key값이 word가 아닌 log_data를 지정하여 보내도록 수정하였습니다.
