### PR TITLE
상세페이지 접근 시에 경고창 발생 오류 해결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,12 +8,12 @@ import { useSetRecoilState, useRecoilValue } from 'recoil'
 
 function App() {
 
-  /* user_auth 쿠키를 확인하는 함수 */
   const { keycloak } = useKeycloak()
   const setIsLoggedIn = useSetRecoilState(isLoggedInAtom)
   const setUserId = useSetRecoilState(userIdAtom)
   const isModalOpen = useRecoilValue(isModalOpenAtom);
 
+  /* user_auth 쿠키를 확인함  */
   useEffect(() => {
     const userAuth = Cookies.get('user_auth')
     
@@ -28,6 +28,7 @@ function App() {
     }
   }, [keycloak.authenticated])
 
+  /* 모달창이 열려있으면 스크롤바를 제거함 */
   useEffect(() => {
     if(isModalOpen) {
       document.body.classList.add('no-scroll')

--- a/src/containers/DetailCarousel/DetailCarousel.tsx
+++ b/src/containers/DetailCarousel/DetailCarousel.tsx
@@ -9,8 +9,8 @@ import 'swiper/css/navigation'
 import 'swiper/css/pagination'
 import 'swiper/swiper.min.css'
 import json from '@/data/PPT_DATA.json'
-import { cartAtom } from '@/atoms/index'
-import { useRecoilState } from 'recoil'
+import { cartAtom, userIdAtom } from '@/atoms/index'
+import { useRecoilState, useRecoilValue } from 'recoil'
 import useBook from '@/hooks/useBook'
 
 interface DetailCarouselProps {
@@ -24,6 +24,7 @@ const DetailCarousel = ({ className, pageId }: DetailCarouselProps) => {
   const folderName = target?.folderName
   const pageTitle = target?.title //상세페이지 제목이 담긴다
   const swiperRef = useRef<SwiperRef>(null)
+  const userId = useRecoilValue(userIdAtom)
 
   // 이미지 로드 실패시 기본 이미지를 로드하는 함수
   const handleImageError = (
@@ -42,12 +43,14 @@ const DetailCarousel = ({ className, pageId }: DetailCarouselProps) => {
     // 컴포넌트가 렌더링된 다음 cart의 값으로 id, title 키를 가진 객체가 저장된다
     setCart({ id: Number(pageId), title: pageTitle })
   }, [])
-
+  
   useEffect(() => {
     // 상세페이지가 장바구니에 들어가있는 지를 확인한다
     // cart Atom을 추적하고 있어, cart Atom이 업데이트된 다음에 실행될 수 있게끔 했다.
-    checkBook()
-  }, [cart])
+    if(userId) {
+      checkBook()
+    }
+  }, [cart, userId])
 
   const imagePaths = Array.from(
     { length: fileList.length },

--- a/src/hooks/useBook.ts
+++ b/src/hooks/useBook.ts
@@ -28,9 +28,8 @@ const useBook = () => {
           setBook(false)
         }
       })
-      .catch((err) => {
-        console.log(err.message)
-        // setAlert({visible: true, option: 'cartError'})
+      .catch(() => {
+        setAlert({visible: true, option: 'cartError'})
       })
   }
 


### PR DESCRIPTION
![호출오류1](https://github.com/sosin-t3q/education-system/assets/79128016/f11282ac-39b2-4b4e-a085-6c4b1358e525)

사용자가 로그인을 하고 상세페이지에 접근할 때 장바구니 데이터를 호출과 관련된 경고창이 발생하는 에러가 있었습니다. 

![호출오류2](https://github.com/sosin-t3q/education-system/assets/79128016/25eae116-ddef-466d-8db0-099edf531c57)

이것은 API 통신에 사용되는 URL 주소에 로그인한 사용자가 가진 고유 id값이 비어있는 상태로 호출이 되어서 발생하는 일이었습니다. 로그인에 성공하면 App.tsx에서 userId 상태변수에 고유 id값을 저장시켜두는 게 리액트의 state 업데이트는 비동기적으로 일어나서 발생하는 문제였습니다.

![해결1](https://github.com/sosin-t3q/education-system/assets/79128016/6992bc58-d3c5-40f0-89e1-1ab4eeacb062)

사용자가 상세페이지에 접근할 경우 DetailCarousel.tsx에서 checkBook()이 실행됩니다. 여기서 원래는 곧바로 checkBook()이 발생했지만 조건문 안에서 checkBook()을 다루고, useEffect로 하여금 userId 상태변수를 추적하도록 해둠으로 더 이상 비정상적인 호출은 발생하지 않습니다.