### PR TITLE
도메인 직접 접근 방지 기능

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { useKeycloak } from '@react-keycloak/web'
 import { Intro, Home, Detail, School } from '@/pages'
 import { isLoggedInAtom, userIdAtom, isModalOpenAtom } from './atoms'
 import { useSetRecoilState, useRecoilValue } from 'recoil'
+import { PrivateRoute } from '@/components'
 
 function App() {
 
@@ -42,7 +43,9 @@ function App() {
       <Routes>
         <Route path="/" element={<Intro />}></Route>
         <Route path="/home" element={<Home />}></Route>
-        <Route path="/detail/:id" element={<Detail />}></Route>
+        <Route element={<PrivateRoute />}>
+          <Route path="/detail/:id" element={<Detail />}></Route>
+        </Route>
         <Route path="/school" element={<School />}></Route>
         <Route path="*" element={<div>404 페이지</div>}></Route>
       </Routes>

--- a/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/src/components/PrivateRoute/PrivateRoute.tsx
@@ -1,37 +1,11 @@
-//Ver1.
-// import { ReactNode } from "react";
-// import { useKeycloak } from "@react-keycloak/web";
+import { Navigate, Outlet } from 'react-router-dom';
+import { useRecoilValue } from 'recoil'
+import { isLoggedInAtom } from '@/atoms'
 
-// const PrivateRoute = ({ children }:{children: ReactNode}) => {
+const PrivateRoute = () => {
+  const isLoggedIn = useRecoilValue(isLoggedInAtom);
 
-//     const { keycloak } = useKeycloak();
-//     const isLoggedIn = keycloak.authenticated;
-
-//     return isLoggedIn ? children : null;
-// };
-
-// export default PrivateRoute;
-
-//Ver2.
-import { useKeycloak } from '@react-keycloak/web'
-import { useEffect, ReactNode } from 'react'
-
-const PrivateRoute = ({ children }: { children: ReactNode }) => {
-  const { keycloak } = useKeycloak()
-
-  const isLoggedIn = keycloak.authenticated
-
-  useEffect(() => {
-    if (!isLoggedIn) {
-      keycloak.login()
-    }
-  }, [isLoggedIn, keycloak])
-
-  if (!isLoggedIn) {
-    return <div>Loading...</div>
-  }
-
-  return children
+  return isLoggedIn ? <Outlet /> : <Navigate to="/home"/>
 }
 
-export default PrivateRoute
+export default PrivateRoute;


### PR DESCRIPTION
![도메인해결1](https://github.com/sosin-t3q/education-system/assets/79128016/47899070-0c19-4843-87ff-fa37152e5eb1)

원래 로그인을 하지 않은 사용자가 URL을 통해 상세페이지에 직접 접근할 수 있었던 걸 막아뒀습니다.

![도메인해결2](https://github.com/sosin-t3q/education-system/assets/79128016/9560a929-acfc-46ae-9ac8-8b79e950ecdf)

사용자가 로그인에 성공할 경우 isLoggedIn 상태변수에 값이 들어가고, 아닌 경우에는 비어있습니다. 이 점을 활용해 
PrivateRoute.tsx에서 사용자가 상세페이지에 접근할 경우 isLoggedIn의 값을 확인해 값이 있는 경우에는 상세페이지를 
보여주고 아닐 경우에는 홈으로 돌아가게끔 해뒀습니다.