### PR TITLE
[🔧수정] 도메인 접근 제한 기능 수정

### DIFF
--- a/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/src/components/PrivateRoute/PrivateRoute.tsx
@@ -1,11 +1,15 @@
 import { Navigate, Outlet } from 'react-router-dom';
-import { useRecoilValue } from 'recoil'
-import { isLoggedInAtom } from '@/atoms'
+import Cookies from 'js-cookie';
 
 const PrivateRoute = () => {
-  const isLoggedIn = useRecoilValue(isLoggedInAtom);
+  const userAuth = Cookies.get('user_auth')
 
-  return isLoggedIn ? <Outlet /> : <Navigate to="/home"/>
+  if(userAuth) {
+    return  <Outlet />
+  } else {
+    return <Navigate to="/home"/>
+  }
+
 }
 
 export default PrivateRoute;


### PR DESCRIPTION
isLoggedIn 상태변수를 활용한 접근 제한 기능을 할 경우, 사용자가 상세페이지에서 새로고침을 하면 상태변수가 초기화되어 
메인페이지로 강제 이동되는 문제점이 파악됐습니다. 

이를 해결하기 위해 쿠키 안의 user_auth를 확인하는 방법으로 해뒀습니다