### PR TITLE
[🔧수정] 비디오 변환 조건 제거

### DIFF
--- a/src/axios/getSubPageData.ts
+++ b/src/axios/getSubPageData.ts
@@ -36,7 +36,7 @@ const fetchData = async (
           newData = { ...res['case_data'], data_list: caseData }
         }
         break
-      case id === '13' || id === '1207':
+      case id === '13':
         {
           const data = await convertVideo(
             res['case_data']['data_list'],


### PR DESCRIPTION
브라우저 렌더링 목적으로 예제 데이터 영상을 임의로 변환하던 상태를 원래대로 바꾸었습니다.