### PR TITLE
[🔧수정] draw 예제 전달 value 값 변경

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -56,7 +56,8 @@ const Input = ({ selected, getData, type }: InputProps) => {
   }, [selected, recording, recordBase64])
 
   const canvasData = (data: string | null) => {
-    getData(data)
+    if (!data) return
+    getData(['drawData', data])
   }
 
   let inner = <p>로딩 중...</p>


### PR DESCRIPTION
손그림 예제 구분을 위해 전달 되는 값을 배열로 임의로 변경했습니다.