### PR TITLE
이미지 분류예제 value 값에 따라 다르게 api 호출 하도록 조건문 추가하였습니다.

### DIFF
--- a/src/axios/case28/imageProcessor.ts
+++ b/src/axios/case28/imageProcessor.ts
@@ -2,23 +2,6 @@ import axiosRequest from '@/axios/axiosRequest'
 import base64DataToFile from '@/axios/base64DataToFile'
 import { SetterOrUpdater } from 'recoil'
 
-let apiType = 'file'
-
-const getConvertData = async (mode: string, value: string | string[]) => {
-  // eslint-disable-next-line no-constant-condition
-  if (mode === 'anomaly' || 'regression') {
-    // Image anomaly, regression 예제는 image/jpeg 파일로 변환하여 전송
-    return await base64DataToFile(value, 'image', 'image/jpeg')
-  } else if (mode === 'classification') {
-    apiType = 'canvas'
-
-    return await base64DataToFile(value, 'image', 'image/png')
-  }
-
-  // 나머지 예제는 image/png 파일로 변환하여 전송
-  return await base64DataToFile(value, 'image', 'image/png')
-}
-
 const imageProcessor = async (
   targetId: any,
   mode: 'classification' | 'anomaly' | 'clustering' | 'regression' | string,
@@ -29,6 +12,9 @@ const imageProcessor = async (
 ) => {
   let resultData = ''
   let returnDirectly = false
+  let apiType = 'file'
+  let convertData: File
+  const typeCheck = typeof value
 
   type infoType = {
     [key: string]: string
@@ -53,18 +39,21 @@ const imageProcessor = async (
     sunglasses: '선글라스',
   }
 
-  const convertData = await getConvertData(mode, value)
-
-  // // eslint-disable-next-line no-constant-condition
-  // if (mode === 'anomaly' || 'regression') {
-  //   // Image anomaly, regression 예제는 image/jpeg 파일로 변환하여 전송
-  //   convertData = await base64DataToFile(value, 'image', 'image/jpeg')
-  // } else if (mode === 'classification') {
-  //   apiType = 'canvas'
-  // } else {
-  //   // 나머지 예제는 image/png 파일로 변환하여 전송
-  //   convertData = await base64DataToFile(value, 'image', 'image/png')
-  // }
+  // eslint-disable-next-line no-constant-condition
+  if (mode === 'anomaly' || mode === 'regression') {
+    // Image anomaly, regression 예제는 image/jpeg 파일로 변환하여 전송
+    convertData = await base64DataToFile(value, 'image', 'image/jpeg')
+  } else if (mode === 'classification') {
+    if (typeCheck == 'object') {
+      apiType = 'canvas'
+      convertData = await base64DataToFile(value[1], 'image', 'image/png')
+    } else {
+      convertData = await base64DataToFile(value, 'image', 'image/jpeg')
+    }
+  } else {
+    // 나머지 예제는 image/png 파일로 변환하여 전송
+    convertData = await base64DataToFile(value, 'image', 'image/png')
+  }
 
   /* FormData에 전달받은 값을 입력 */
   const formData = new FormData()


### PR DESCRIPTION
### 변경사항

![image](https://github.com/sosin-t3q/education-system/assets/96248861/81461990-5c4c-4716-ae2a-4ef364f22602)
![image](https://github.com/sosin-t3q/education-system/assets/96248861/7d0c709e-d1d6-4828-84bc-07c8de7979cb)

- 백엔드 팀의 요청에 따라 손그림 이미지 분류 예제에서 샘플 이미지가 아닌 직접 그린 이미지를 전송할 경우에는 원래 값인 file_req_ajx에 api호출을 하지 않고 canvas_req_ajx에 요청을 보내도록 수정하였습니다.
- 손그림 이미지 분류에서 직접 그린 경우에는 value 값을 배열로 미리 넘겨주고 통신부분에서 손그림 이미지 분류에서 value 값이 배열인 경우에는 canvas_req_ajx로 변경하여 요청하도록 수정하였습니다. 