### PR TITLE
[🐞버그] 인풋 밸류 실시간 반영 안됨 버그 수정

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -23,7 +23,6 @@ const Input = ({ selected, getData, type }: InputProps) => {
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value)
-    if (value.trim().length === 0) return // 입력된 값이 없다면
     getData(e.target.value)
   }
 

--- a/src/containers/DetailForm/DetailForm.tsx
+++ b/src/containers/DetailForm/DetailForm.tsx
@@ -134,6 +134,11 @@ const DetailForm = ({ data }: DetailFormProps) => {
 
   const onClick = useCallback(async () => {
     sourceRef.current = axios.CancelToken.source()
+    if (typeof value === 'string' && value.trim().length === 0) {
+      setAlert({ visible: true, option: 'nullError' })
+
+      return
+    }
     if (value) {
       const inferResult = await combinedProcessor(
         pageId,


### PR DESCRIPTION
텍스트 입력 예제에서 인풋의 두 번째 입력부터 value가 업데이트 되는 현상이 발생했습니다.
인풋 onChange 이벤트에 공백 처리 로직을 넣어놓은 것이 원인인 것으로 확인 되었으며, 해당 로직은 DetailForm의 데이터 요청 이벤트 함수 내부로 옮겨 해결하였습니다.